### PR TITLE
Reduce waypoint count to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ python - <<'PY'
 import torch
 class Dummy(torch.nn.Module):
     def forward(self, x):
-        return torch.zeros(20,4)
+        return torch.zeros(16,4)
 torch.jit.trace(Dummy(), torch.zeros(1)).save('models/mobilenet_dummy.pt')
 PY
 ```
@@ -21,7 +21,7 @@ PY
 Prepare a dataset saved as an `.npz` file containing arrays `laser`,
 `global_wp` and `local_wp`. Each sample should stack one 1081-element
 laser scan with a corresponding global waypoint track to form a
-two-channel input. `local_wp` should contain the target 20 waypoints
+two-channel input. `local_wp` should contain the target 16 waypoints
 with `(x, y, yaw, v)` for each step.
 
 Train the MobileNetV2-based planner and export a TorchScript model with:

--- a/config/planner_params.yaml
+++ b/config/planner_params.yaml
@@ -1,4 +1,4 @@
-horizon: 20
+horizon: 16
 speed: 1.0
 steering_angle: 0.0
 model_path: models/mobilenet_dummy.pt

--- a/models/mobilenet_v2_1d.py
+++ b/models/mobilenet_v2_1d.py
@@ -150,7 +150,7 @@ class MobileNetV2Backbone1D(nn.Module):
 
 
 class PlannerMobileNet1D(nn.Module):
-    """Full 1D MobileNetV2 model for predicting 20 waypoints."""
+    """Full 1D MobileNetV2 model for predicting 16 waypoints."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -160,24 +160,24 @@ class PlannerMobileNet1D(nn.Module):
         self.xy_head = nn.Sequential(
             nn.Linear(self.backbone.last_channel, hidden),
             nn.ReLU(inplace=True),
-            nn.Linear(hidden, 40),
+            nn.Linear(hidden, 32),
         )
         self.yaw_head = nn.Sequential(
             nn.Linear(self.backbone.last_channel, hidden),
             nn.ReLU(inplace=True),
-            nn.Linear(hidden, 20),
+            nn.Linear(hidden, 16),
         )
         self.vel_head = nn.Sequential(
             nn.Linear(self.backbone.last_channel, hidden),
             nn.ReLU(inplace=True),
-            nn.Linear(hidden, 20),
+            nn.Linear(hidden, 16),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.backbone(x)
         x = x.flatten(1)
-        xy = self.xy_head(x).view(-1, 20, 2)
-        yaw = self.yaw_head(x).view(-1, 20, 1)
-        vel = self.vel_head(x).view(-1, 20, 1)
+        xy = self.xy_head(x).view(-1, 16, 2)
+        yaw = self.yaw_head(x).view(-1, 16, 1)
+        vel = self.vel_head(x).view(-1, 16, 1)
         return torch.cat((xy, yaw, vel), dim=2)
 

--- a/scripts/planner_node.py
+++ b/scripts/planner_node.py
@@ -14,7 +14,7 @@ class PlannerNode(Node):
         super().__init__('planner_node')
         self.declare_parameters('', [
             ('model_path', 'models/mobilenet_dummy.pt'),
-            ('horizon', 20),
+            ('horizon', 16),
             ('speed', 1.0),
             ('steering_angle', 0.0),
         ])

--- a/scripts/train_mobilenet.py
+++ b/scripts/train_mobilenet.py
@@ -15,7 +15,7 @@ class WaypointDataset(Dataset):
     Expects an ``.npz`` file with arrays ``laser``, ``global_wp`` and
     ``local_wp``. ``laser`` and ``global_wp`` should have shape ``(N, 1081)``
     and will be stacked to form the 2-channel input. ``local_wp`` should have
-    shape ``(N, 20, 4)`` representing ``x, y, yaw`` and ``v`` for each step in
+    shape ``(N, 16, 4)`` representing ``x, y, yaw`` and ``v`` for each step in
     the horizon.
     """
 


### PR DESCRIPTION
## Summary
- Update MobileNet planner model to output 16 waypoints
- Adjust training script, node parameters, and docs for 16-step horizon

## Testing
- `python -m py_compile models/mobilenet_v2_1d.py scripts/train_mobilenet.py scripts/planner_node.py`


------
https://chatgpt.com/codex/tasks/task_e_68a19ef1685c8320862cb874b0aa174b