### PR TITLE
Integrate MobileNetV2-based planner training

### DIFF
--- a/models/colab_training.py
+++ b/models/colab_training.py
@@ -1,63 +1,80 @@
+import argparse
+import os
+from typing import Tuple
+
+import numpy as np
 import torch
-from torch import nn, optim
-from torch.utils.data import DataLoader, Dataset
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+from models.mobilenet_v2_1d import PlannerMobileNet1D
 
 
-class RandomDataset(Dataset):
-    """Dataset of random images and labels for demonstration purposes."""
+class WaypointDataset(Dataset):
+    """Dataset for local planner training.
 
-    def __init__(self, length: int = 1000) -> None:
-        self.length = length
+    Expects an ``.npz`` file with arrays ``laser``, ``global_wp`` and
+    ``local_wp``. ``laser`` and ``global_wp`` should have shape ``(N, 1081)``
+    and will be stacked to form the 2-channel input. ``local_wp`` should have
+    shape ``(N, 16, 4)`` representing ``x, y, yaw`` and ``v`` for each step in
+    the horizon.
+    """
 
-    def __len__(self) -> int:  # type: ignore[override]
-        return self.length
+    def __init__(self, path: str) -> None:
+        data = np.load(path)
+        laser = data["laser"].astype(np.float32)
+        global_wp = data["global_wp"].astype(np.float32)
+        inputs = np.stack((laser, global_wp), axis=1)
+        self.inputs = torch.from_numpy(inputs)
+        self.targets = torch.from_numpy(data["local_wp"].astype(np.float32))
 
-    def __getitem__(self, idx: int):  # type: ignore[override]
-        image = torch.randn(1, 28, 28)
-        label = torch.randint(0, 10, (1,)).item()
-        return image, label
+    def __len__(self) -> int:
+        return self.inputs.shape[0]
 
-
-def load_data(batch_size: int = 64) -> DataLoader:
-    dataset = RandomDataset()
-    return DataLoader(dataset, batch_size=batch_size, shuffle=True)
-
-
-class SimpleNet(nn.Module):
-    """Simple fully connected network for classification."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.flatten = nn.Flatten()
-        self.fc1 = nn.Linear(28 * 28, 128)
-        self.relu = nn.ReLU()
-        self.fc2 = nn.Linear(128, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        x = self.flatten(x)
-        x = self.relu(self.fc1(x))
-        return self.fc2(x)
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.inputs[idx], self.targets[idx]
 
 
-def train(model: nn.Module, loader: DataLoader, device: torch.device) -> None:
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.Adam(model.parameters(), lr=0.001)
-    model.train()
-    for images, labels in loader:
-        images, labels = images.to(device), labels.to(device)
-        optimizer.zero_grad()
-        outputs = model(images)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
+def train(model: nn.Module, loader: DataLoader, epochs: int, lr: float) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    criterion = nn.MSELoss()
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    for epoch in range(epochs):
+        model.train()
+        running = 0.0
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            optim.zero_grad()
+            pred = model(x)
+            loss = criterion(pred, y)
+            loss.backward()
+            optim.step()
+            running += loss.item() * x.size(0)
+        print(f"epoch {epoch+1}: loss={running/len(loader.dataset):.4f}")
 
 
 def main() -> None:
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    train_loader = load_data()
-    model = SimpleNet().to(device)
-    train(model, train_loader, device)
-    torch.save(model.state_dict(), "random_model.pth")
+    parser = argparse.ArgumentParser(description="Train MobileNetV2 local planner")
+    parser.add_argument("data", help="Path to training data .npz file")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument(
+        "--out",
+        default="models/mobilenet_trained.pt",
+        help="Output TorchScript model path",
+    )
+    args = parser.parse_args()
+
+    dataset = WaypointDataset(args.data)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    model = PlannerMobileNet1D()
+    train(model, loader, epochs=args.epochs, lr=args.lr)
+    example = torch.zeros(1, 2, 1081)
+    traced = torch.jit.trace(model.cpu(), example)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    traced.save(args.out)
+    print(f"saved model to {args.out}")
 
 
 if __name__ == "__main__":

--- a/models/mobilenet_v2_1d.py
+++ b/models/mobilenet_v2_1d.py
@@ -1,0 +1,182 @@
+"""1D adaptation of MobileNetV2 for waypoint prediction."""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+import torch
+from torch import nn
+
+
+def _make_divisible(v: float, divisor: int, min_value: Optional[int] = None) -> int:
+    """Ensure that all layers have a channel number that is divisible by the divisor."""
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return int(new_v)
+
+
+class ConvBNAct1D(nn.Sequential):
+    """Convolution + BatchNorm + Activation block for 1D inputs."""
+
+    def __init__(
+        self,
+        in_planes: int,
+        out_planes: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        groups: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm1d
+        padding = (kernel_size - 1) // 2
+        super().__init__(
+            nn.Conv1d(
+                in_planes,
+                out_planes,
+                kernel_size,
+                stride,
+                padding,
+                groups=groups,
+                bias=False,
+            ),
+            norm_layer(out_planes),
+            nn.ReLU6(inplace=True),
+        )
+
+
+class InvertedResidual1D(nn.Module):
+    """Inverted residual block for 1D inputs."""
+
+    def __init__(
+        self,
+        inp: int,
+        oup: int,
+        stride: int,
+        expand_ratio: int,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm1d
+        hidden_dim = int(round(inp * expand_ratio))
+        self.use_res_connect = stride == 1 and inp == oup
+
+        layers: List[nn.Module] = []
+        if expand_ratio != 1:
+            layers.append(ConvBNAct1D(inp, hidden_dim, kernel_size=1, norm_layer=norm_layer))
+        layers.extend(
+            [
+                ConvBNAct1D(
+                    hidden_dim,
+                    hidden_dim,
+                    stride=stride,
+                    groups=hidden_dim,
+                    norm_layer=norm_layer,
+                ),
+                nn.Conv1d(hidden_dim, oup, 1, 1, 0, bias=False),
+                norm_layer(oup),
+            ]
+        )
+        self.conv = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        if self.use_res_connect:
+            return x + self.conv(x)
+        return self.conv(x)
+
+
+class MobileNetV2Backbone1D(nn.Module):
+    """MobileNetV2 feature extractor using 1D convolutions."""
+
+    def __init__(
+        self,
+        width_mult: float = 1.0,
+        round_nearest: int = 8,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm1d
+        block = InvertedResidual1D
+        input_channel = 32
+        last_channel = 1280
+        input_channel = _make_divisible(input_channel * width_mult, round_nearest)
+        self.last_channel = _make_divisible(last_channel * max(1.0, width_mult), round_nearest)
+
+        features: List[nn.Module] = [
+            ConvBNAct1D(2, input_channel, stride=2, norm_layer=norm_layer)
+        ]
+        # t, c, n, s
+        inverted_residual_setting = [
+            [1, 16, 1, 1],
+            [6, 24, 2, 2],
+            [6, 32, 3, 2],
+            [6, 64, 4, 2],
+            [6, 96, 3, 1],
+            [6, 160, 3, 2],
+            [6, 320, 1, 1],
+        ]
+
+        for t, c, n, s in inverted_residual_setting:
+            output_channel = _make_divisible(c * width_mult, round_nearest)
+            for i in range(n):
+                stride_value = s if i == 0 else 1
+                features.append(
+                    block(
+                        input_channel,
+                        output_channel,
+                        stride_value,
+                        expand_ratio=t,
+                        norm_layer=norm_layer,
+                    )
+                )
+                input_channel = output_channel
+
+        features.append(
+            ConvBNAct1D(input_channel, self.last_channel, kernel_size=1, norm_layer=norm_layer)
+        )
+        self.features = nn.Sequential(*features)
+        self.pool = nn.AdaptiveAvgPool1d(1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = self.features(x)
+        x = self.pool(x)
+        return x
+
+
+class PlannerMobileNet1D(nn.Module):
+    """Full 1D MobileNetV2 model for predicting 16 waypoints."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.backbone = MobileNetV2Backbone1D()
+        hidden = 256
+        # Multi-head structure for separate predictions
+        self.xy_head = nn.Sequential(
+            nn.Linear(self.backbone.last_channel, hidden),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden, 32),
+        )
+        self.yaw_head = nn.Sequential(
+            nn.Linear(self.backbone.last_channel, hidden),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden, 16),
+        )
+        self.vel_head = nn.Sequential(
+            nn.Linear(self.backbone.last_channel, hidden),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden, 16),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = self.backbone(x)
+        x = x.flatten(1)
+        xy = self.xy_head(x).view(-1, 16, 2)
+        yaw = self.yaw_head(x).view(-1, 16, 1)
+        vel = self.vel_head(x).view(-1, 16, 1)
+        return torch.cat((xy, yaw, vel), dim=2)


### PR DESCRIPTION
## Summary
- add 1D MobileNetV2 planner model with multi-head waypoint outputs
- replace colab training script with dataset-driven trainer using the new model

## Testing
- `python -m py_compile models/mobilenet_v2_1d.py models/colab_training.py`
- ❌ `python models/colab_training.py --help` (missing torch; large dependency download)


------
https://chatgpt.com/codex/tasks/task_e_68a2eb7c73c48320a736a504eb2ccfdd